### PR TITLE
feat: client configuration and retries

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,8 +22,8 @@ import (
 )
 
 func main() {
-	// Or you can use NewClientWithDebug() to enable debugging,
-	// this will print requests before and after they are sent
+	// For custom configurations, you can use NewClientWithConfig(),
+	// you will need to provide an api.EquinoxConfig{} object
 	client, err := equinox.NewClient("RIOT_API_KEY")
 
 	if err != nil {
@@ -45,10 +45,16 @@ func main() {
 
 ## TODO
 
-### Tests
+### Improve tests
 
 I am not sure if tests are 'good enough', I am just checking if errors are `Nil` and the response is `NotNil` using `testify`.
 
-### Logging
+Sometimes an endpoint method might return a valid 404 error, for example, getting an active game by a summoner's ID, this might not find a game for a valid summoner, returning a 404. I am unsure what the best solution for this problem might be.
+
+### Improve Requests api
+
+At the moment `GET` and other methods needs to go through the same function, InternalClient.Do(). It would be better to have specific functions for each http method.
+
+### Improve Logging
 
 I don't believe the current logging and 'debugging mode' is done right or that its 'done' at all to be honest, there might be places where I should be logging something but I am not.

--- a/api/config.go
+++ b/api/config.go
@@ -1,0 +1,31 @@
+package api
+
+import (
+	"os"
+	"time"
+)
+
+// An config object for the EquinoxClient
+type EquinoxConfig struct {
+	// Riot API Key
+	Key string
+	// Debug mode. Default: false
+	Debug bool
+	// Timeout for http.Request in milliseconds, 0 disables it. Default: 2000 milliseconds
+	Timeout time.Duration
+	// Retry request if it returns a 429 status code. Default: true
+	Retry bool
+	// Retry count. Default: 1
+	RetryCount int8
+}
+
+// Creates an EquinoxConfig for tests
+func NewTestEquinoxConfig() *EquinoxConfig {
+	return &EquinoxConfig{
+		Key:        os.Getenv("RIOT_API_KEY"),
+		Debug:      true,
+		Timeout:    2000,
+		Retry:      true,
+		RetryCount: 1,
+	}
+}

--- a/api/constants.go
+++ b/api/constants.go
@@ -1,11 +1,11 @@
 package api
 
-type Region string
-
 const (
 	// Base API URL format
 	BaseURLFormat = "https://%s.api.riotgames.com"
 )
+
+type Region string
 
 // Riot API routes
 const (

--- a/api/errors.go
+++ b/api/errors.go
@@ -1,0 +1,25 @@
+package api
+
+import "net/http"
+
+type ErrorResponse struct {
+	Status Status `json:"status"`
+}
+
+type Status struct {
+	Message    string `json:"message"`
+	StatusCode int    `json:"status_code"`
+}
+
+func (e ErrorResponse) Error() string {
+	return e.Status.Message
+}
+
+var (
+	NotFoundError = ErrorResponse{
+		Status: Status{
+			Message:    "Not Found",
+			StatusCode: http.StatusNotFound,
+		},
+	}
+)

--- a/equinox.go
+++ b/equinox.go
@@ -3,6 +3,7 @@ package equinox
 import (
 	"fmt"
 
+	"github.com/Kyagara/equinox/api"
 	"github.com/Kyagara/equinox/internal"
 	"github.com/Kyagara/equinox/lol"
 )
@@ -12,13 +13,28 @@ type Equinox struct {
 	LOL            *lol.LOLClient
 }
 
-// Creates a new Equinox client
+/*
+	Creates a new Equinox client with a default configuration
+
+		- `Debug`      : false
+		- `Timeout`    : 2000
+		- `Retry`      : true
+		- `RetryCount` : 1
+*/
 func NewClient(key string) (*Equinox, error) {
 	if key == "" {
 		return nil, fmt.Errorf("API Key not provided")
 	}
 
-	internalClient := internal.NewInternalClient(key, false)
+	config := &api.EquinoxConfig{
+		Key:        key,
+		Debug:      false,
+		Timeout:    2000,
+		Retry:      true,
+		RetryCount: 1,
+	}
+
+	internalClient := internal.NewInternalClient(config)
 
 	client := &Equinox{
 		internalClient: internalClient,
@@ -28,13 +44,21 @@ func NewClient(key string) (*Equinox, error) {
 	return client, nil
 }
 
-// Creates a new Equinox client with debug
-func NewClientWithDebug(key string) (*Equinox, error) {
-	if key == "" {
+/*
+	Creates a new Equinox client using a custom configuration,
+
+	If you don't specify a Timeout this will disable the timeout for the http.Client
+*/
+func NewClientWithConfig(config *api.EquinoxConfig) (*Equinox, error) {
+	if config.Key == "" {
 		return nil, fmt.Errorf("API Key not provided")
 	}
 
-	internalClient := internal.NewInternalClient(key, true)
+	if config.Retry && config.RetryCount < 1 {
+		config.RetryCount = 1
+	}
+
+	internalClient := internal.NewInternalClient(config)
 
 	client := &Equinox{
 		internalClient: internalClient,

--- a/equinox_test.go
+++ b/equinox_test.go
@@ -1,15 +1,15 @@
 package equinox_test
 
 import (
-	"os"
 	"testing"
 
 	"github.com/Kyagara/equinox"
+	"github.com/Kyagara/equinox/api"
 	"github.com/stretchr/testify/assert"
 )
 
 func TestNewEquinoxClient(t *testing.T) {
-	client, err := equinox.NewClientWithDebug(os.Getenv("RIOT_API_KEY"))
+	client, err := equinox.NewClientWithConfig(api.NewTestEquinoxConfig())
 
 	assert.Nil(t, err, "expecting nil error")
 

--- a/internal/client.go
+++ b/internal/client.go
@@ -3,16 +3,21 @@ package internal
 import (
 	"encoding/json"
 	"fmt"
+	"io"
 	"net/http"
 	"strconv"
 	"time"
+
+	"github.com/Kyagara/equinox/api"
 )
 
 type InternalClient struct {
-	key   string
-	debug bool
-	http  *http.Client
-	log   *Logger
+	key        string
+	debug      bool
+	retry      bool
+	retryCount int8
+	http       *http.Client
+	log        *Logger
 }
 
 const (
@@ -20,29 +25,49 @@ const (
 )
 
 // Returns a new client using the API key provided
-func NewInternalClient(key string, debug bool) *InternalClient {
+func NewInternalClient(config *api.EquinoxConfig) *InternalClient {
 	return &InternalClient{
-		key:   key,
-		debug: debug,
-		http:  &http.Client{Timeout: 5 * time.Second},
-		log:   NewLogger(),
+		key:        config.Key,
+		debug:      config.Debug,
+		retry:      config.Retry,
+		retryCount: config.RetryCount,
+		http:       &http.Client{Timeout: config.Timeout},
+		log:        NewLogger(),
 	}
 }
 
-type ErrorResponse struct {
-	Status struct {
-		Message    string `json:"message"`
-		StatusCode int    `json:"status_code"`
-	} `json:"status"`
-}
+// Executes a http request
+func (c *InternalClient) Do(method string, region api.Region, endpoint string, object interface{}) error {
+	baseUrl := fmt.Sprintf(api.BaseURLFormat, region)
 
-// Creates and sends a request using the parameters specified
-func (c *InternalClient) SendRequest(method string, url string, endpoint string, v interface{}) error {
 	// Creating a new *http.Request
-	req, err := c.newRequest(method, fmt.Sprintf("%s%s", url, endpoint))
+	req, err := c.newRequest(method, fmt.Sprintf("%s%s", baseUrl, endpoint))
 
 	if err != nil {
 		return err
+	}
+
+	// Sending http request and returning the response
+	res, err := c.sendRequest(req, method, endpoint, 0)
+
+	if err != nil {
+		return err
+	}
+
+	// Decoding the body into the endpoint method response object
+	if err = json.Unmarshal(res, &object); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+// Sends a http request
+func (c *InternalClient) sendRequest(req *http.Request, method string, endpoint string, retryCount int8) ([]byte, error) {
+	if retryCount >= c.retryCount {
+		msg := fmt.Sprintf(LogRequestFormat, method, endpoint, fmt.Sprintf("Failed %d times, stopping", retryCount))
+
+		return nil, fmt.Errorf(msg)
 	}
 
 	if c.debug {
@@ -53,55 +78,89 @@ func (c *InternalClient) SendRequest(method string, url string, endpoint string,
 	res, err := c.http.Do(req)
 
 	if err != nil {
-		return err
+		return nil, err
 	}
 
 	defer res.Body.Close()
 
-	// If the API returns with a 429, get the Retry-After header and retry after the specified time has passed
+	if res.StatusCode == http.StatusUnauthorized || res.StatusCode == http.StatusForbidden {
+		return nil, c.newErrorResponse(res)
+	}
+
+	// If the API returns a 429 code
 	if res.StatusCode == http.StatusTooManyRequests {
+		if c.debug {
+			c.log.Error.Printf(LogRequestFormat, method, endpoint, "Too many requests")
+		}
+
+		// If Retry is disabled just return an error
+		if !c.retry {
+			return nil, c.newErrorResponse(res)
+		}
+
 		retryAfter := res.Header.Get("Retry-After")
+
+		// If the header isn't found, don't retry and return error
+		if retryAfter == "" {
+			if c.debug {
+				c.log.Error.Printf(LogRequestFormat, method, endpoint, "Retry-After header not found, not retrying")
+			}
+
+			return nil, fmt.Errorf("rate limited, status code 429")
+		}
 
 		seconds, err := strconv.Atoi(retryAfter)
 
 		if err != nil {
-			return err
+			return nil, err
 		}
 
 		if c.debug {
-			c.log.Error.Printf(LogRequestFormat, method, endpoint, fmt.Sprintf("Too many requests, retrying in %ds", seconds))
+			c.log.Error.Printf(LogRequestFormat, method, endpoint, fmt.Sprintf("Retrying in %ds", seconds))
 		}
 
 		time.Sleep(time.Duration(seconds) * time.Second)
 
-		return c.SendRequest(method, url, endpoint, v)
+		return c.sendRequest(req, method, endpoint, retryCount+1)
 	}
 
-	// If the status code is lower than 200 or higher than 400
-	if res.StatusCode < http.StatusOK || res.StatusCode >= http.StatusBadRequest {
-		var errRes ErrorResponse
-
-		if err = json.NewDecoder(res.Body).Decode(&errRes); err == nil {
-			return fmt.Errorf("status code: %d, %v", errRes.Status.StatusCode, errRes.Status.Message)
+	// If the API returns a 404 code, return an error
+	if res.StatusCode == http.StatusNotFound {
+		if c.debug {
+			c.log.Warn.Printf(LogRequestFormat, method, endpoint, "Not Found")
 		}
 
-		return fmt.Errorf("unknown error, status code: %d", res.StatusCode)
+		return nil, api.NotFoundError
 	}
 
-	// Decoding the json into the endpoint method response object
-	if err = json.NewDecoder(res.Body).Decode(&v); err != nil {
-		return err
+	// If the status code is lower than 200 or higher than 400, return an error.
+	if res.StatusCode < http.StatusOK || res.StatusCode > http.StatusBadRequest {
+		if c.debug {
+			c.log.Error.Printf(LogRequestFormat, method, endpoint, "Retrying")
+		}
+
+		return nil, c.newErrorResponse(res)
 	}
 
 	if c.debug {
 		c.log.Info.Printf(LogRequestFormat, method, endpoint, "Request successful")
 	}
 
-	return nil
+	body, err := io.ReadAll(res.Body)
+
+	if err != nil {
+		return nil, err
+	}
+
+	return body, nil
 }
 
-// Creates a new *http.request and sets headers
+// Creates a new *http.Request and sets headers
 func (c *InternalClient) newRequest(method string, url string) (*http.Request, error) {
+	if c.key == "" {
+		return nil, fmt.Errorf("API Key not provided")
+	}
+
 	req, err := http.NewRequest(method, url, nil)
 
 	if err != nil {
@@ -112,4 +171,17 @@ func (c *InternalClient) newRequest(method string, url string) (*http.Request, e
 	req.Header.Set("X-Riot-Token", c.key)
 
 	return req, nil
+}
+
+// Returns an error from the *http.Response provided
+func (c *InternalClient) newErrorResponse(res *http.Response) error {
+	var errRes api.ErrorResponse
+
+	err := json.NewDecoder(res.Body).Decode(&errRes)
+
+	if err != nil {
+		return errRes
+	}
+
+	return errRes
 }

--- a/internal/client_test.go
+++ b/internal/client_test.go
@@ -1,16 +1,16 @@
 package internal_test
 
 import (
-	"os"
 	"testing"
 
+	"github.com/Kyagara/equinox/api"
 	"github.com/Kyagara/equinox/internal"
 	"github.com/Kyagara/equinox/lol"
 	"github.com/stretchr/testify/assert"
 )
 
 func TestNewInternalClient(t *testing.T) {
-	internalClient := internal.NewInternalClient(os.Getenv("RIOT_API_KEY"), true)
+	internalClient := internal.NewInternalClient(api.NewTestEquinoxConfig())
 
 	client := lol.NewLOLClient(internalClient)
 

--- a/lol/champion.go
+++ b/lol/champion.go
@@ -1,7 +1,7 @@
 package lol
 
 import (
-	"fmt"
+	"net/http"
 
 	"github.com/Kyagara/equinox/api"
 	"github.com/Kyagara/equinox/internal"
@@ -11,17 +11,19 @@ type ChampionEndpoint struct {
 	internalClient *internal.InternalClient
 }
 
-type ChampionInfo struct {
-	FreeChampionIds              []int `json:"freeChampionIds"`
-	FreeChampionIdsForNewPlayers []int `json:"freeChampionIdsForNewPlayers"`
-	MaxNewPlayerLevel            int   `json:"maxNewPlayerLevel"`
+type ChampionInfoDTO struct {
+	FreeChampionIds              []int16 `json:"freeChampionIds"`
+	FreeChampionIdsForNewPlayers []int16 `json:"freeChampionIdsForNewPlayers"`
+	MaxNewPlayerLevel            uint8   `json:"maxNewPlayerLevel"`
 }
 
 // Get Free Champions Rotation
-func (c *ChampionEndpoint) FreeRotation(region api.Region) (*ChampionInfo, error) {
-	res := ChampionInfo{}
+func (c *ChampionEndpoint) FreeRotation(region api.Region) (*ChampionInfoDTO, error) {
+	res := ChampionInfoDTO{}
 
-	if err := c.internalClient.SendRequest("GET", fmt.Sprintf(api.BaseURLFormat, region), ChampionEndpointURL, &res); err != nil {
+	err := c.internalClient.Do(http.MethodGet, region, ChampionEndpointURL, &res)
+
+	if err != nil {
 		return nil, err
 	}
 

--- a/lol/champion_test.go
+++ b/lol/champion_test.go
@@ -1,7 +1,6 @@
 package lol_test
 
 import (
-	"os"
 	"testing"
 
 	"github.com/Kyagara/equinox/api"
@@ -11,7 +10,7 @@ import (
 )
 
 func TestFreeChampionsRotation(t *testing.T) {
-	internalClient := internal.NewInternalClient(os.Getenv("RIOT_API_KEY"), true)
+	internalClient := internal.NewInternalClient(api.NewTestEquinoxConfig())
 
 	client := lol.NewLOLClient(internalClient)
 

--- a/lol/client.go
+++ b/lol/client.go
@@ -6,23 +6,25 @@ import (
 
 // League of Legends endpoints
 const (
-	ChampionEndpointURL = "/lol/platform/v3/champion-rotations"
-	StatusEndpointURL   = "/lol/status/v4/platform-data"
+	ChampionEndpointURL            = "/lol/platform/v3/champion-rotations"
+	StatusEndpointURL              = "/lol/status/v4/platform-data"
+	SpectatorEndpointURL           = "/lol/spectator/v4/featured-games"
+	SpectatorBySummonerEndpointURL = "/lol/spectator/v4/active-games/by-summoner/%s"
 )
 
 type LOLClient struct {
 	internalClient *internal.InternalClient
 	Champion       *ChampionEndpoint
 	Status         *StatusEndpoint
+	Spectator      *SpectatorEndpoint
 }
 
-// Creates a new LOLClient using a InternalClient
+// Creates a new LOLClient using an InternalClient provided
 func NewLOLClient(client *internal.InternalClient) *LOLClient {
 	return &LOLClient{
 		internalClient: client,
 		Champion:       &ChampionEndpoint{internalClient: client},
-		Status: &StatusEndpoint{
-			internalClient: client,
-		},
+		Status:         &StatusEndpoint{internalClient: client},
+		Spectator:      &SpectatorEndpoint{internalClient: client},
 	}
 }

--- a/lol/client_test.go
+++ b/lol/client_test.go
@@ -1,16 +1,16 @@
 package lol_test
 
 import (
-	"os"
 	"testing"
 
+	"github.com/Kyagara/equinox/api"
 	"github.com/Kyagara/equinox/internal"
 	"github.com/Kyagara/equinox/lol"
 	"github.com/stretchr/testify/assert"
 )
 
 func TestNewLOLClient(t *testing.T) {
-	internalClient := internal.NewInternalClient(os.Getenv("RIOT_API_KEY"), true)
+	internalClient := internal.NewInternalClient(api.NewTestEquinoxConfig())
 
 	client := lol.NewLOLClient(internalClient)
 

--- a/lol/spectator.go
+++ b/lol/spectator.go
@@ -1,0 +1,108 @@
+package lol
+
+import (
+	"fmt"
+	"net/http"
+
+	"github.com/Kyagara/equinox/api"
+	"github.com/Kyagara/equinox/internal"
+)
+
+type SpectatorEndpoint struct {
+	internalClient *internal.InternalClient
+}
+
+type FeaturedGamesDTO struct {
+	GameList []struct {
+		GameID            int    `json:"gameId"`
+		MapID             int    `json:"mapId"`
+		GameMode          string `json:"gameMode"`
+		GameType          string `json:"gameType"`
+		GameQueueConfigID int    `json:"gameQueueConfigId"`
+		Participants      []struct {
+			TeamID        int    `json:"teamId"`
+			Spell1ID      int    `json:"spell1Id"`
+			Spell2ID      int    `json:"spell2Id"`
+			ChampionID    int    `json:"championId"`
+			ProfileIconID int    `json:"profileIconId"`
+			SummonerName  string `json:"summonerName"`
+			Bot           bool   `json:"bot"`
+		} `json:"participants"`
+		Observers struct {
+			EncryptionKey string `json:"encryptionKey"`
+		} `json:"observers"`
+		PlatformID      string `json:"platformId"`
+		BannedChampions []struct {
+			ChampionID int `json:"championId"`
+			TeamID     int `json:"teamId"`
+			PickTurn   int `json:"pickTurn"`
+		} `json:"bannedChampions"`
+		GameStartTime int `json:"gameStartTime"`
+		GameLength    int `json:"gameLength"`
+	} `json:"gameList"`
+	ClientRefreshInterval int `json:"clientRefreshInterval"`
+}
+
+type ActiveGameBySummonerID struct {
+	GameID            int    `json:"gameId"`
+	MapID             int    `json:"mapId"`
+	GameMode          string `json:"gameMode"`
+	GameType          string `json:"gameType"`
+	GameQueueConfigID int    `json:"gameQueueConfigId"`
+	Participants      []struct {
+		TeamID                   int    `json:"teamId"`
+		Spell1ID                 int    `json:"spell1Id"`
+		Spell2ID                 int    `json:"spell2Id"`
+		ChampionID               int    `json:"championId"`
+		ProfileIconID            int    `json:"profileIconId"`
+		SummonerName             string `json:"summonerName"`
+		Bot                      bool   `json:"bot"`
+		SummonerID               string `json:"summonerId"`
+		GameCustomizationObjects []struct {
+			Category string `json:"category"`
+			Content  string `json:"content"`
+		} `json:"gameCustomizationObjects"`
+		Perks struct {
+			PerkIds      []int `json:"perkIds"`
+			PerkStyle    int   `json:"perkStyle"`
+			PerkSubStyle int   `json:"perkSubStyle"`
+		} `json:"perks"`
+	} `json:"participants"`
+	Observers struct {
+		EncryptionKey string `json:"encryptionKey"`
+	} `json:"observers"`
+	PlatformID      string `json:"platformId"`
+	BannedChampions []struct {
+		ChampionID int `json:"championId"`
+		TeamID     int `json:"teamId"`
+		PickTurn   int `json:"pickTurn"`
+	} `json:"bannedChampions"`
+	GameStartTime int `json:"gameStartTime"`
+	GameLength    int `json:"gameLength"`
+}
+
+// Get featured games in a region
+func (c *SpectatorEndpoint) FeaturedGames(region api.Region) (*FeaturedGamesDTO, error) {
+	res := FeaturedGamesDTO{}
+
+	err := c.internalClient.Do(http.MethodGet, region, SpectatorEndpointURL, &res)
+
+	if err != nil {
+		return nil, err
+	}
+
+	return &res, nil
+}
+
+// Get an active game by summoner ID
+func (c *SpectatorEndpoint) ActiveGameBySummonerID(region api.Region, summonerId string) (*ActiveGameBySummonerID, error) {
+	res := ActiveGameBySummonerID{}
+
+	err := c.internalClient.Do(http.MethodGet, region, fmt.Sprintf(SpectatorBySummonerEndpointURL, summonerId), &res)
+
+	if err != nil {
+		return nil, err
+	}
+
+	return &res, nil
+}

--- a/lol/spectator_test.go
+++ b/lol/spectator_test.go
@@ -1,0 +1,44 @@
+package lol_test
+
+import (
+	"testing"
+
+	"github.com/Kyagara/equinox/api"
+	"github.com/Kyagara/equinox/internal"
+	"github.com/Kyagara/equinox/lol"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestFeaturedGames(t *testing.T) {
+	internalClient := internal.NewInternalClient(api.NewTestEquinoxConfig())
+
+	client := lol.NewLOLClient(internalClient)
+
+	res, err := client.Spectator.FeaturedGames(api.LOLRegionNA1)
+
+	assert.Nil(t, err, "expecting nil error")
+
+	assert.NotNil(t, res, "expecting non-nil response")
+}
+
+func TestActiveGameBySummonerID(t *testing.T) {
+	internalClient := internal.NewInternalClient(api.NewTestEquinoxConfig())
+
+	client := lol.NewLOLClient(internalClient)
+
+	res, err := client.Spectator.ActiveGameBySummonerID(api.LOLRegionBR1, "5kIdR5x9LO0pVU_v01FtNVlb-dOws-D04GZCbNOmxCrB7A")
+
+	// What should be done in cases where a 404 is a valid response?
+
+	// If there's an error, it could be that no summoner was in a match when this was called.
+
+	// How can we test this?
+	if err != nil && err == api.NotFoundError {
+		require.NotNil(t, err, "expecting non-nil error")
+	}
+
+	if err == nil {
+		require.NotNil(t, res, "expecting non-nil response")
+	}
+}

--- a/lol/status.go
+++ b/lol/status.go
@@ -1,7 +1,7 @@
 package lol
 
 import (
-	"fmt"
+	"net/http"
 	"time"
 
 	"github.com/Kyagara/equinox/api"
@@ -12,46 +12,69 @@ type StatusEndpoint struct {
 	internalClient *internal.InternalClient
 }
 
-type PlatformDataDto struct {
-	ID           string      `json:"id"`
-	Name         string      `json:"name"`
-	Locales      []string    `json:"locales"`
-	Maintenances []StatusDto `json:"maintenances"`
-	Incidents    []StatusDto `json:"incidents"`
-}
-
-type ContentDto struct {
-	Content string `json:"content"`
-	Locale  string `json:"locale"`
-}
-
-type UpdateDto struct {
-	UpdatedAt        string       `json:"updated_at"`
-	Translations     []ContentDto `json:"translations"`
-	Author           string       `json:"author"`
-	Publish          bool         `json:"publish"`
-	CreatedAt        time.Time    `json:"created_at"`
-	ID               int          `json:"id"`
-	PublishLocations []string     `json:"publish_locations"`
-}
-
-type StatusDto struct {
-	ArchiveAt         time.Time    `json:"archive_at"`
-	Titles            []ContentDto `json:"titles"`
-	UpdatedAt         time.Time    `json:"updated_at"`
-	IncidentSeverity  string       `json:"incident_severity"`
-	Platforms         []string     `json:"platforms"`
-	Updates           []UpdateDto  `json:"updates"`
-	CreatedAt         time.Time    `json:"created_at"`
-	ID                int          `json:"id"`
-	MaintenanceStatus string       `json:"maintenance_status"`
+type PlatformDataDTO struct {
+	ID           string   `json:"id"`
+	Name         string   `json:"name"`
+	Locales      []string `json:"locales"`
+	Maintenances []struct {
+		ArchiveAt time.Time `json:"archive_at"`
+		Titles    []struct {
+			Content string `json:"content"`
+			Locale  string `json:"locale"`
+		} `json:"titles"`
+		UpdatedAt        time.Time `json:"updated_at"`
+		IncidentSeverity string    `json:"incident_severity"`
+		Platforms        []string  `json:"platforms"`
+		Updates          []struct {
+			UpdatedAt    string `json:"updated_at"`
+			Translations []struct {
+				Content string `json:"content"`
+				Locale  string `json:"locale"`
+			} `json:"translations"`
+			Author           string    `json:"author"`
+			Publish          bool      `json:"publish"`
+			CreatedAt        time.Time `json:"created_at"`
+			ID               int       `json:"id"`
+			PublishLocations []string  `json:"publish_locations"`
+		} `json:"updates"`
+		CreatedAt         time.Time `json:"created_at"`
+		ID                int       `json:"id"`
+		MaintenanceStatus string    `json:"maintenance_status"`
+	} `json:"maintenances"`
+	Incidents []struct {
+		ArchiveAt time.Time `json:"archive_at"`
+		Titles    []struct {
+			Content string `json:"content"`
+			Locale  string `json:"locale"`
+		} `json:"titles"`
+		UpdatedAt        time.Time `json:"updated_at"`
+		IncidentSeverity string    `json:"incident_severity"`
+		Platforms        []string  `json:"platforms"`
+		Updates          []struct {
+			UpdatedAt    time.Time `json:"updated_at"`
+			Translations []struct {
+				Content string `json:"content"`
+				Locale  string `json:"locale"`
+			} `json:"translations"`
+			Author           string    `json:"author"`
+			Publish          bool      `json:"publish"`
+			CreatedAt        time.Time `json:"created_at"`
+			ID               int       `json:"id"`
+			PublishLocations []string  `json:"publish_locations"`
+		} `json:"updates"`
+		CreatedAt         time.Time `json:"created_at"`
+		ID                int       `json:"id"`
+		MaintenanceStatus string    `json:"maintenance_status"`
+	} `json:"incidents"`
 }
 
 // Get Status
-func (c *StatusEndpoint) Status(region api.Region) (*PlatformDataDto, error) {
-	res := PlatformDataDto{}
+func (c *StatusEndpoint) GetStatus(region api.Region) (*PlatformDataDTO, error) {
+	res := PlatformDataDTO{}
 
-	if err := c.internalClient.SendRequest("GET", fmt.Sprintf(api.BaseURLFormat, region), StatusEndpointURL, &res); err != nil {
+	err := c.internalClient.Do(http.MethodGet, region, StatusEndpointURL, &res)
+
+	if err != nil {
 		return nil, err
 	}
 

--- a/lol/status_test.go
+++ b/lol/status_test.go
@@ -1,7 +1,6 @@
 package lol_test
 
 import (
-	"os"
 	"testing"
 
 	"github.com/Kyagara/equinox/api"
@@ -10,12 +9,12 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-func TestStatus(t *testing.T) {
-	internalClient := internal.NewInternalClient(os.Getenv("RIOT_API_KEY"), true)
+func TestGetStatus(t *testing.T) {
+	internalClient := internal.NewInternalClient(api.NewTestEquinoxConfig())
 
 	client := lol.NewLOLClient(internalClient)
 
-	res, err := client.Status.Status(api.LOLRegionNA1)
+	res, err := client.Status.GetStatus(api.LOLRegionNA1)
 
 	assert.Nil(t, err, "expecting nil error")
 


### PR DESCRIPTION
A Equinox client with custom configuration can be created with equinox.NewClientWithConfig(), it needs a api.EquinoxConfig{} struct as a parameter.

If Retry is enabled it will retry request that received a 429 response.