### PR TITLE
fix X-Riot-Token being shared across clients

### DIFF
--- a/internal/client.go
+++ b/internal/client.go
@@ -26,12 +26,6 @@ var (
 	ErrKeyNotProvided = errors.New("api key not provided")
 )
 
-var (
-	apiHeaders = http.Header{
-		"X-Riot-Token": {""},
-	}
-)
-
 type Client struct {
 	http               *http.Client
 	cache              *cache.Cache
@@ -77,7 +71,6 @@ func NewInternalClient(config api.EquinoxConfig, h *http.Client, c *cache.Cache,
 		IsRetryEnabled:     config.Retry.MaxRetries > 0,
 	}
 
-	apiHeaders.Set("X-Riot-Token", config.Key)
 	return client, nil
 }
 
@@ -107,7 +100,7 @@ func (c *Client) Request(ctx context.Context, logger zerolog.Logger, httpMethod 
 		return api.EquinoxRequest{}, err
 	}
 
-	request.Header = apiHeaders
+	request.Header.Set("X-Riot-Token", c.key)
 
 	equinoxReq := api.EquinoxRequest{
 		Logger:   logger,

--- a/internal/client_test.go
+++ b/internal/client_test.go
@@ -161,6 +161,31 @@ func TestRequests(t *testing.T) {
 	})
 }
 
+func TestPerClientRiotToken(t *testing.T) {
+	t.Parallel()
+
+	cfgA := util.NewTestEquinoxConfig()
+	cfgA.Key = "RGAPI-AAA"
+	clientA, err := internal.NewInternalClient(cfgA, nil, nil, nil)
+	require.NoError(t, err)
+
+	cfgB := util.NewTestEquinoxConfig()
+	cfgB.Key = "RGAPI-BBB"
+	clientB, err := internal.NewInternalClient(cfgB, nil, nil, nil)
+	require.NoError(t, err)
+
+	ctx := context.Background()
+	urlComponents := []string{"https://", "", "cool.and.real.api", "/get"}
+
+	reqA, err := clientA.Request(ctx, clientA.Logger("client_endpoint_method_a"), http.MethodGet, urlComponents, "", nil)
+	require.NoError(t, err)
+	reqB, err := clientB.Request(ctx, clientB.Logger("client_endpoint_method_b"), http.MethodGet, urlComponents, "", nil)
+	require.NoError(t, err)
+
+	require.Equal(t, "RGAPI-AAA", reqA.Request.Header.Get("X-Riot-Token"))
+	require.Equal(t, "RGAPI-BBB", reqB.Request.Header.Get("X-Riot-Token"))
+}
+
 func TestExecutes(t *testing.T) {
 	httpmock.Activate()
 	defer httpmock.DeactivateAndReset()

--- a/test/benchmark/parallel_test.go
+++ b/test/benchmark/parallel_test.go
@@ -104,7 +104,7 @@ func BenchmarkParallelRedisCachedSummonerByPUUID(b *testing.B) {
 	})
 }
 
-// This endpoint method clones apiHeaders and adds a new Authorization header.
+// This endpoint method sets an Authorization header on the request.
 func BenchmarkParallelSummonerByAccessToken(b *testing.B) {
 	b.ReportAllocs()
 	httpmock.Activate()


### PR DESCRIPTION
`internal/client.go` stored `X-Riot-Token` on a package-level `apiHeaders` http.Header (line 30), overwrote it on every `NewInternalClient` call (line 80), and assigned that map by reference to every outgoing request (line 110). Constructing multiple `Equinox` clients in the same process made all of them send requests with whichever key was set last. This caused issues for us as we have multiple keys (1 for each game).

Drops the package map and sets `X-Riot-Token` on each request from `c.key`. Adds a regression test that builds two clients with distinct keys and asserts each request carries its own token. Happy to drop the test.